### PR TITLE
Upgrade Django 3.2 → 5.2 LTS and all dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Geo Gems is a Django-based B2B e-commerce website for Infratex (infratex.com.au), an Australian geosynthetics supplier. The site manages product catalogs, technical documentation, case studies, and integrates with Xero for quote management.
 
 ## Tech Stack
-- **Backend:** Django 3.2.9, Python
+- **Backend:** Django 5.2, Python
 - **Database:** SQLite (dev), PostgreSQL (prod)
 - **Storage:** AWS S3 for media files
 - **Integrations:** Xero API for quotes/invoices

--- a/apis/views.py
+++ b/apis/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from apis import constants
 from datetime import datetime, timedelta
-import pytz
+from zoneinfo import ZoneInfo
 import json
 import io
 import os
@@ -118,7 +118,7 @@ Leadtime: {quoteData["leadTime"]}"""
         taxType = "EXEMPTOUTPUT"
         currencyCode = "USD"
 
-    currentDateTime = datetime.now(pytz.timezone('Australia/Victoria'))
+    currentDateTime = datetime.now(ZoneInfo('Australia/Melbourne'))
     today = str(currentDateTime.year)+"-"+str(currentDateTime.month)+"-"+str(currentDateTime.day)
     expiryDateTime = currentDateTime + timedelta(days=14)
     expiryDate = str(expiryDateTime.year)+"-"+str(expiryDateTime.month)+"-"+(str(expiryDateTime.day))

--- a/gems/settings.py
+++ b/gems/settings.py
@@ -52,7 +52,7 @@ INSTALLED_APPS = [
     'nested_admin',
     'apis',
     'knowledge_base',
-    'captcha',
+    'django_recaptcha',
     'tinymce',
 ]
 
@@ -136,8 +136,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 
@@ -168,7 +166,14 @@ STATICFILES_DIRS = [
 ## Media files storage
 # https://docs.djangoproject.com/en/4.2/topics/files/
 
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+STORAGES = {
+    "default": {
+        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
 
 AWS_PUBLIC_STORAGE_BUCKET_NAME = 'infratex-public-assets'
 AWS_PRIVATE_STORAGE_BUCKET_NAME = 'infratex-private-assets'

--- a/gems/settings.py
+++ b/gems/settings.py
@@ -206,8 +206,8 @@ EMAIL_USE_TLS = True
 EMAIL_HOST_USER = 'accounts@geosynthetics.net.au'
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 
-RECAPTCHA_PUBLIC_KEY = os.environ.get('RECAPTCHA_PUBLIC_KEY')
-RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY')
+RECAPTCHA_PUBLIC_KEY = os.environ.get('RECAPTCHA_PUBLIC_KEY', '')
+RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY', '')
 
 # Site ID for enabling sites framework required for sitemap
 # Run a migration to set the correct name and domain for the project

--- a/products/migrations/0009_auto_20250318_0030.py
+++ b/products/migrations/0009_auto_20250318_0030.py
@@ -2,7 +2,7 @@
 
 import datetime
 from django.db import migrations, models
-from django.utils.timezone import utc
+utc = datetime.timezone.utc
 
 
 class Migration(migrations.Migration):

--- a/products/models.py
+++ b/products/models.py
@@ -122,7 +122,6 @@ class ProductMediaRelation(models.Model):
             base = base.replace("_", " ")                           # "my image file"
             self.alt_text = base
         super().save(*args, **kwargs)
-        super().save(*args, **kwargs)
     
     def __str__(self):
         return f"{self.resource_type} for {self.product.code}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,14 @@
-PyMuPDF==1.23.8  # Updated for Python 3.12 compatibility
-asgiref==3.4.1
-dj-database-url==0.5.0
-Django==3.2.9
-gunicorn==20.1.0
-psycopg2-binary==2.9.9
-pytz==2021.3
-sqlparse==0.4.2
-django-storages==1.12.3
-Pillow==10.2.0  # Updated for Python 3.12 - has pre-built wheels, no compilation needed!
-django-nested-admin==3.3.3
-boto3==1.20.16
-requests==2.28.2
-django-recaptcha==3.0.0
-django-tinymce==3.6.1
+Django==5.2
+asgiref>=3.8.1
+dj-database-url==2.3.0
+gunicorn==23.0.0
+psycopg2-binary==2.9.12
+sqlparse==0.5.5
+django-storages[boto3]==1.14.6
+Pillow==11.2.1
+django-nested-admin==4.1.6
+boto3==1.36.26
+requests==2.32.3
+django-recaptcha==4.1.0
+django-tinymce==4.1.0
+PyMuPDF==1.25.3

--- a/storage_backends.py
+++ b/storage_backends.py
@@ -11,8 +11,6 @@ class PublicMediaStorage(S3Boto3Storage):
     location = settings.FOLDER_NAME
 
     def delete(self, name):
-        name = self._normalize_name(self._clean_name(name))
-        self.bucket.Object(name).delete()
         return super().delete(name)
 
     def list_all_filenames(self):


### PR DESCRIPTION
## Summary
- **Django 3.2.9 → 5.2 LTS** (3.2 has been EOL since April 2024)
- All 15 dependencies updated to current versions
- Fixed all breaking changes and deprecations for Django 5.x compatibility

## Changes

### Code fixes
- `apis/views.py` — Replace `pytz` with `zoneinfo`, fix invalid timezone `Australia/Victoria` → `Australia/Melbourne`
- `gems/settings.py` — `DEFAULT_FILE_STORAGE` → `STORAGES` dict, remove `USE_L10N`, update recaptcha app label (`captcha` → `django_recaptcha`), add empty string defaults for recaptcha keys (v4 requires strings, not None)
- `products/migrations/0009` — Fix removed `django.utils.timezone.utc` import
- `products/models.py` — Remove duplicate `super().save()` bug (was causing double DB writes)
- `storage_backends.py` — Remove private method calls (`_normalize_name`, `_clean_name`) that no longer exist in django-storages 1.14
- `CLAUDE.md` — Update version reference

### Dependency updates
| Package | Old | New |
|---|---|---|
| Django | 3.2.9 | 5.2 |
| gunicorn | 20.1.0 | 23.0.0 |
| boto3 | 1.20.16 | 1.36.26 |
| django-storages | 1.12.3 | 1.14.6 |
| django-recaptcha | 3.0.0 | 4.1.0 |
| django-nested-admin | 3.3.3 | 4.1.6 |
| django-tinymce | 3.6.1 | 4.1.0 |
| dj-database-url | 0.5.0 | 2.3.0 |
| Pillow | 10.2.0 | 11.2.1 |
| PyMuPDF | 1.23.8 | 1.25.3 |
| psycopg2-binary | 2.9.9 | 2.9.12 |
| requests | 2.28.2 | 2.32.3 |
| sqlparse | 0.4.2 | 0.5.5 |
| asgiref | 3.4.1 | ≥3.8.1 |
| pytz | 2021.3 | **removed** |

## Test plan
- [x] `manage.py check` — 0 issues
- [x] `manage.py check --deploy` — only pre-existing security warnings
- [x] `manage.py migrate` — all 37 migrations apply cleanly
- [x] `manage.py makemigrations --check` — no new migrations needed
- [x] `manage.py collectstatic` — 461 files, no errors
- [x] `manage.py runserver` — starts and responds on all routes
- [ ] Verify on DigitalOcean App Platform (Postgres + S3 storage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)